### PR TITLE
Create shell scripts for ant build

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ To run the main demo, go to the JFoenix/make directory and run the batch file ru
 
 **NOTE** : You need to update the build.bat to point to Java 1.8 and Apache Ant directories.
 
+**NOTE** : Linux is also supported. In the make directory, use `./build.sh` and `./run-demo.sh`, respectively.
+
 ## Gradle
 To build JFoenix, execute the following command:
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ JFoenix is an open source Java library, that implements Google Material Design u
 
 # Build
 ## Ant
+### Windows
 To build JFoenix, we created an Ant file named build.xml and build.bat. JFoenix uses Java version **1.8 u60**. Using the command line, you need to move to the JFoenix/make directory
 and run the batch file build.bat by typing:
 
@@ -17,6 +18,17 @@ To run the main demo, go to the JFoenix/make directory and run the batch file ru
     run-demo.bat
 
 **NOTE** : You need to update the build.bat to point to Java 1.8 and Apache Ant directories.
+
+### Linux
+JFoenix can also be build on Linux. Similar to on Windows, build.sh was created to do this. Using the command line, enter the JFoenix/make directory and run the shell script build.sh by typing:
+
+    ./build.sh
+
+To run the main demo, go to the JFoenix/make directory and run the shell script run-demo.sh:
+
+    ./run-demo.sh
+
+**NOTE** : Java and ant need to be installed and configured.
 
 ## Gradle
 To build JFoenix, execute the following command:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ JFoenix is an open source Java library, that implements Google Material Design u
 
 # Build
 ## Ant
-### Windows
 To build JFoenix, we created an Ant file named build.xml and build.bat. JFoenix uses Java version **1.8 u60**. Using the command line, you need to move to the JFoenix/make directory
 and run the batch file build.bat by typing:
 
@@ -18,17 +17,6 @@ To run the main demo, go to the JFoenix/make directory and run the batch file ru
     run-demo.bat
 
 **NOTE** : You need to update the build.bat to point to Java 1.8 and Apache Ant directories.
-
-### Linux
-JFoenix can also be build on Linux. Similar to on Windows, build.sh was created to do this. Using the command line, enter the JFoenix/make directory and run the shell script build.sh by typing:
-
-    ./build.sh
-
-To run the main demo, go to the JFoenix/make directory and run the shell script run-demo.sh:
-
-    ./run-demo.sh
-
-**NOTE** : Java and ant need to be installed and configured.
 
 ## Gradle
 To build JFoenix, execute the following command:

--- a/make/build.sh
+++ b/make/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Echo an error message to the user.
+error () {
+    echo "Error:"  $1 >&2
+    exit 1
+}
+
+# Ensure java is installed and JAVA_HOME is set. Ant requires this.
+if [ -z "$JAVA_HOME" ];
+    then
+        # IF JAVA_HOME not set, try to set it by finding where javac is.
+        command -v javac >/dev/null 2>&1;
+        if [ $? -eq 0 ];
+            then
+                # Javac was found, now set JAVA_HOME
+                export JAVA_HOME=$(readlink -f $(command -v javac) | sed "s:/bin/javac::");
+
+            else
+                # Javac could not be found, exit and fail.
+                error "JAVA_HOME is not set, is java installed?";
+        fi
+    
+    # Javac cannot be found, and JAVA_HOME isn't set.
+    else
+        error "JAVA_HOME not set, is java installed?";
+fi
+
+# Ensure ant is installed
+command -v ant >/dev/null 2>&1 || { error "ant cannot be found, is it\
+    installed?"; }
+
+# Set some arguments for ant.
+export ANT_OPTS="-Xms1024m -Xmx1024m"
+
+# Finally, build.
+ant -f build.xml

--- a/make/run-demo.sh
+++ b/make/run-demo.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Echo an error message to the user.
+error () {
+    echo "Error:"  $1 >&2
+    exit 1
+}
+
+# Ensure java is installed and JAVA_HOME is set. Ant requires this.
+if [ -z "$JAVA_HOME" ];
+    then
+        # IF JAVA_HOME not set, try to set it by finding where javac is.
+        command -v javac >/dev/null 2>&1;
+        if [ $? -eq 0 ];
+            then
+                # Javac was found, now set JAVA_HOME.
+                export JAVA_HOME=$(readlink -f $(command -v javac) | sed "s:/bin/javac::");
+
+            else
+                # Javac could not be found, exit and fail.
+                error "JAVA_HOME is not set, is java installed?";
+        fi
+fi
+
+# Ensure ant is installed
+command -v ant >/dev/null 2>&1 || { error "ant cannot be found, is it\
+    installed?"; }
+
+# Set some arguments for ant.
+export ANT_OPTS="-Xms1024m -Xmx1024m"
+
+# Finally, build.
+ant -f build-demo.xml


### PR DESCRIPTION
Allows better cross-platform compatibility. Build instructions are also updated in readme. Steps to build using ant on Linux remain same as on Windows, albeit with the shell scripts, not the batch files.