### PR TITLE
Restore interruption status on InterruptedException

### DIFF
--- a/src/com/jfoenix/concurrency/JFXUtilities.java
+++ b/src/com/jfoenix/concurrency/JFXUtilities.java
@@ -53,6 +53,7 @@ public class JFXUtilities {
 			doneLatch.await();
 		}
 		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 		}
 	}
 }


### PR DESCRIPTION
As described in Java Concurrency In Practice, pp. 92ff.,
InterruptedException should either be propagated to the caller
or the interruption status should be restored.
See [the original text](https://cdn.rawgit.com/HackathonHackers/programming-ebooks/master/Java/Java%20Concurrency%20in%20Practice.pdf#page=114).
(Go to pages 114f.. of the PDF if it does not scroll automatically, it's pages 92ff. in the original book)