### PR TITLE
Update JFoenix Version in Gradle Configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To run the main demo, execute the following command:
 Reference the repository from this location using:
 
     dependencies {
-      compile 'com.jfoenix:jfoenix:1.0.0'
+      compile 'com.jfoenix:jfoenix:1.2.0'
     }
 
 # Pics


### PR DESCRIPTION
I noticed that some features are not available inside the old version 1.0.0, e.g., JFXTreeView. As a result, it's better to notify the readers that the newest version when they are using Gradle.