### PR TITLE
fix the timePickerContest.updateValue DateTimeParseException

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/skins/JFXTimePickerContent.java
+++ b/jfoenix/src/main/java/com/jfoenix/skins/JFXTimePickerContent.java
@@ -522,8 +522,7 @@ public class JFXTimePickerContent extends VBox {
             timePicker.setValue(localTimeStringConverter.fromString(selectedHourLabel.getText()
                                                                     + ":" + selectedMinLabel.getText()));
         } else {
-            String input = selectedHourLabel.getText() + ":" + selectedMinLabel.getText() + " " + period.get();
-            timePicker.setValue(LocalTime.parse(input, DateTimeFormatter.ofPattern("h:mm a").withLocale(Locale.ENGLISH)));
+            timePicker.setValue(LocalTime.parse(selectedHourLabel.getText() + ":" + selectedMinLabel.getText() + " " + period.get(), DateTimeFormatter.ofPattern("h:mm a").withLocale(Locale.ENGLISH)));
         }
     }
 

--- a/jfoenix/src/main/java/com/jfoenix/skins/JFXTimePickerContent.java
+++ b/jfoenix/src/main/java/com/jfoenix/skins/JFXTimePickerContent.java
@@ -43,6 +43,7 @@ import javafx.util.converter.NumberStringConverter;
 
 import java.awt.geom.Point2D;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.Locale;
 
@@ -521,10 +522,8 @@ public class JFXTimePickerContent extends VBox {
             timePicker.setValue(localTimeStringConverter.fromString(selectedHourLabel.getText()
                                                                     + ":" + selectedMinLabel.getText()));
         } else {
-            LocalTimeStringConverter localTimeStringConverter =
-                new LocalTimeStringConverter(FormatStyle.SHORT, Locale.ENGLISH);
-            timePicker.setValue(localTimeStringConverter.fromString(selectedHourLabel.getText()
-                                                                    + ":" + selectedMinLabel.getText() + " " + period.get()));
+            String input = selectedHourLabel.getText() + ":" + selectedMinLabel.getText() + " " + period.get();
+            timePicker.setValue(LocalTime.parse(input, DateTimeFormatter.ofPattern("h:mm a").withLocale(Locale.ENGLISH)));
         }
     }
 


### PR DESCRIPTION
Java get default locale for JVM from windows preference.
My default locale for JVM was korean and It thorws an exception even I
set LocalTimeStringConverter to English.

We can set the locale for jvm in several ways.

(http://www.oracle.com/technetwork/articles/javase/locale-140624.html#using)

But the best way is change some code.
I use DateTimeFormatter not localTiemStringConverter.