### PR TITLE
Fixed spelling mistake in JFXDrawer

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXDrawer.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXDrawer.java
@@ -455,8 +455,14 @@ public class JFXDrawer extends StackPane {
     private boolean isRunningTransition(Transition transition) {
         return transition.getStatus() == Status.RUNNING;
     }
-
+    
+    @Deprecated		//wrong spelling
     public boolean isHidding() {
+        return (isRunningTransition(drawerTransition) && this.drawerTransition.getRate() < 0)
+            || (partialTransition instanceof DrawerPartialTransitionHide && isRunningTransition(partialTransition));
+    }
+    
+    public boolean isHiding() {
         return (isRunningTransition(drawerTransition) && this.drawerTransition.getRate() < 0)
             || (partialTransition instanceof DrawerPartialTransitionHide && isRunningTransition(partialTransition));
     }


### PR DESCRIPTION
isHiding() instead of isHidding() (deprecated old method) for anyone still using it

- extremely minor but it was bugging me
- not sure why the pull request showed me the whole file not just the new lines added(first ever pr)