### PR TITLE
Set custom message to Validator constructor

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/validation/base/ValidatorBase.java
+++ b/jfoenix/src/main/java/com/jfoenix/validation/base/ValidatorBase.java
@@ -43,6 +43,11 @@ public abstract class ValidatorBase extends Parent {
 
     private Tooltip tooltip = null;
 
+    public ValidatorBase(String message) {
+        this.setMessage(message);
+        this();
+    }
+    
     public ValidatorBase() {
         parentProperty().addListener((o, oldVal, newVal) -> parentChanged());
     }


### PR DESCRIPTION
Adding message String to constructor allows you to short validator creation:

Before:
```java
RequiredFieldValidator val = new RequiredFieldValidator();
val.setMessage("Custom message");
myInput.getValidators().add(val);
```

After:
```java
myInput.getValidators().add(new RequiredFieldValidator("My custom message"));
```