### PR TITLE
Add css 'jfx-size' property to resize toggle button

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXToggleButton.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXToggleButton.java
@@ -287,7 +287,7 @@ public class JFXToggleButton extends ToggleButton {
                 }
 
                 @Override
-                public StyleableProperty<Paint> getStyleableProperty(JFXToggleButton control) {
+                public StyleableProperty<Number> getStyleableProperty(JFXToggleButton control) {
                     return control.sizeProperty();
                 }
             };

--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXToggleButton.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXToggleButton.java
@@ -199,6 +199,48 @@ public class JFXToggleButton extends ToggleButton {
         this.untoggleLineColor.set(color);
     }
 
+    /**
+     * default line color used when the button is not toggled
+     */
+    private StyleableIntegerProperty untoggleLineColor = new SimpleStyleableIntegerProperty<>(
+        StyleableProperties.UNTOGGLE_LINE_COLOR,
+        JFXToggleButton.this,
+        "unToggleLineColor",
+        Color.valueOf("#999999"));
+
+    public Paint getUnToggleLineColor() {
+        return untoggleLineColor == null ? Color.valueOf("#999999") : untoggleLineColor.get();
+    }
+
+    public StyleableObjectProperty<Paint> unToggleLineColorProperty() {
+        return this.untoggleLineColor;
+    }
+
+    public void setUnToggleLineColor(Paint color) {
+        this.untoggleLineColor.set(color);
+    }
+
+    /**
+     * Default size of the toggle button.
+     */
+    private final StyleableDoubleProperty size = new SimpleStyleableDoubleProperty(
+        StyleableProperties.SIZE,
+        JFXToggleButton.this,
+        "size",
+        10.0);
+
+    public double getSize() {
+        return size.get();
+    }
+
+    public StyleableDoubleProperty sizeProperty() {
+        return this.size;
+    }
+
+    public void setSize(double size) {
+        this.size.set(size);
+    }
+
 
     private static class StyleableProperties {
         private static final CssMetaData<JFXToggleButton, Paint> TOGGLE_COLOR =
@@ -257,6 +299,20 @@ public class JFXToggleButton extends ToggleButton {
                 }
             };
 
+        private static final CssMetaData<JFXToggleButton, Number> SIZE =
+            new CssMetaData<JFXToggleButton, Number>("-jfx-size",
+                StyleConverter.getSizeConverter(), 10.0) {
+                @Override
+                public boolean isSettable(JFXToggleButton control) {
+                    return !control.size.isBound();
+                }
+
+                @Override
+                public StyleableProperty<Paint> getStyleableProperty(JFXToggleButton control) {
+                    return control.sizeProperty();
+                }
+            };
+
 
         private static final List<CssMetaData<? extends Styleable, ?>> CHILD_STYLEABLES;
 
@@ -264,6 +320,7 @@ public class JFXToggleButton extends ToggleButton {
             final List<CssMetaData<? extends Styleable, ?>> styleables =
                 new ArrayList<>(Control.getClassCssMetaData());
             Collections.addAll(styleables,
+                SIZE,
                 TOGGLE_COLOR,
                 UNTOGGLE_COLOR,
                 TOGGLE_LINE_COLOR,

--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXToggleButton.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXToggleButton.java
@@ -200,27 +200,6 @@ public class JFXToggleButton extends ToggleButton {
     }
 
     /**
-     * default line color used when the button is not toggled
-     */
-    private StyleableIntegerProperty untoggleLineColor = new SimpleStyleableIntegerProperty<>(
-        StyleableProperties.UNTOGGLE_LINE_COLOR,
-        JFXToggleButton.this,
-        "unToggleLineColor",
-        Color.valueOf("#999999"));
-
-    public Paint getUnToggleLineColor() {
-        return untoggleLineColor == null ? Color.valueOf("#999999") : untoggleLineColor.get();
-    }
-
-    public StyleableObjectProperty<Paint> unToggleLineColorProperty() {
-        return this.untoggleLineColor;
-    }
-
-    public void setUnToggleLineColor(Paint color) {
-        this.untoggleLineColor.set(color);
-    }
-
-    /**
      * Default size of the toggle button.
      */
     private final StyleableDoubleProperty size = new SimpleStyleableDoubleProperty(

--- a/jfoenix/src/main/java/com/jfoenix/skins/JFXToggleButtonSkin.java
+++ b/jfoenix/src/main/java/com/jfoenix/skins/JFXToggleButtonSkin.java
@@ -49,7 +49,7 @@ public class JFXToggleButtonSkin extends ToggleButtonSkin {
     private Line line;
 
     private Circle circle;
-    private final int circleRadius = 10;
+    private final double circleRadius;
     private StackPane circleContainer = new StackPane();
 
     private JFXRippler rippler;
@@ -59,13 +59,15 @@ public class JFXToggleButtonSkin extends ToggleButtonSkin {
     public JFXToggleButtonSkin(JFXToggleButton toggleButton) {
         super(toggleButton);
 
-        final int startY = 0;
-        final int endX = 22;
-        final int startX = 0;
+        final double size = toggleButton.getSize();
+        final double startY = 0;
+        final double endX = size * 2 + 2;
+        final double startX = 0;
+        circleRadius = toggleButton.getSize();
         line = new Line(startX, startY, endX, startY);
 
         line.setStroke(toggleButton.getUnToggleLineColor());
-        line.setStrokeWidth(14);
+        line.setStrokeWidth(size * 1.5);
         line.setStrokeLineCap(StrokeLineCap.ROUND);
 
         circle = new Circle(startX - circleRadius, startY, circleRadius);
@@ -76,7 +78,7 @@ public class JFXToggleButtonSkin extends ToggleButtonSkin {
 
         StackPane circlePane = new StackPane();
         circlePane.getChildren().add(circle);
-        circlePane.setPadding(new Insets(14));
+        circlePane.setPadding(new Insets(size * 1.5));
         rippler = new JFXRippler(circlePane, RipplerMask.CIRCLE, RipplerPos.BACK) {
             @Override
             protected void initListeners() {


### PR DESCRIPTION
There is no way to decide the size of JFXToggleButton, because the values of the size are unmodifiable.
This pull request aims at adding an easy way to resize the JFXToggleButton.