### PR TITLE
Fixed demo sizing issue & updated readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -179,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
+      boilerplate notice, with the fields enclosed by brackets "{}"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -187,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright {yyyy} {name of copyright owner}
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run the main demo, execute the following command:
 **NOTE** : JFoenix requires **Java 1.8 u60** and above.
 
 # How Can I Use JFoenix?
- You can download the source code of the library and build it as mentioned previously. Building JFoenix will generate jfoenix.jar under the build/dist folder. To use JFoenix, import jfoenix.jar into your project and start using the new material design Java components :).
+You can download the source code of the library and build it as mentioned previously. Building JFoenix will generate jfoenix-0.0.0-SNAPSHOT.jar under the jfoenix/build/libs folder. To use JFoenix, import jfoenix-0.0.0-SNAPSHOT.jar into your project and start using the new material design Java components :).
 
 ## Gradle
 ### How to Include In Gradle Project

--- a/demo/src/main/java/demos/MainDemo.java
+++ b/demo/src/main/java/demos/MainDemo.java
@@ -42,7 +42,7 @@ public class MainDemo extends Application {
 
         JFXDecorator decorator = new JFXDecorator(stage, container.getView());
         decorator.setCustomMaximize(true);
-        Scene scene = new Scene(decorator);
+        Scene scene = new Scene(decorator, 800, 600);
         final ObservableList<String> stylesheets = scene.getStylesheets();
         stylesheets.addAll(MainDemo.class.getResource("/css/jfoenix-fonts.css").toExternalForm(),
                            MainDemo.class.getResource("/css/jfoenix-design.css").toExternalForm(),

--- a/demo/src/main/java/demos/MainDemo.java
+++ b/demo/src/main/java/demos/MainDemo.java
@@ -42,13 +42,11 @@ public class MainDemo extends Application {
 
         JFXDecorator decorator = new JFXDecorator(stage, container.getView());
         decorator.setCustomMaximize(true);
-        Scene scene = new Scene(decorator, 800, 850);
+        Scene scene = new Scene(decorator);
         final ObservableList<String> stylesheets = scene.getStylesheets();
         stylesheets.addAll(MainDemo.class.getResource("/css/jfoenix-fonts.css").toExternalForm(),
                            MainDemo.class.getResource("/css/jfoenix-design.css").toExternalForm(),
                            MainDemo.class.getResource("/css/jfoenix-main-demo.css").toExternalForm());
-        stage.setMinWidth(700);
-        stage.setMinHeight(800);
         stage.setScene(scene);
         stage.show();
     }


### PR DESCRIPTION
Running the demo on a mac book pro 13' opens a window that exceeds the limits of the screen. Additionally, the window is unable to be resized because of the fixed minimum dimensions. As you can see below.

<img width="1280" alt="pre-update" src="https://user-images.githubusercontent.com/12780053/29695259-d3204a40-890f-11e7-88b7-978b93c7fc62.png">

I removed the fixed minimum dimensions, so that the resulting smaller window can be maximized to the individual's screen. 

<img width="442" alt="post-update" src="https://user-images.githubusercontent.com/12780053/29695268-dbb0c5ea-890f-11e7-9a78-cd73a44b3d60.png">

Finally, I updated the README to include the specific path and file names to the JAR generated via Gradle. 