### PR TITLE
Fixed JFXDialogLayout body alignment

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXDialogLayout.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXDialogLayout.java
@@ -127,7 +127,7 @@ public class JFXDialogLayout extends StackPane {
         this.setStyle("-fx-text-fill: rgba(0, 0, 0, 0.87);");
         heading.setStyle("-fx-font-weight: BOLD;-fx-alignment: center-left;");
         heading.setPadding(new Insets(5, 0, 5, 0));
-        body.setStyle("-fx-pref-width: 400px;-fx-wrap-text: true;");
+        body.setStyle("-fx-pref-width: 400px;-fx-wrap-text: true; -fx-alignment: center-left;");
         actions.setStyle("-fx-alignment: center-right ;");
         actions.setPadding(new Insets(10, 0, 0, 0));
     }


### PR DESCRIPTION
Added center-left alignment property for nodes within the body of JFXDialogLayout. The heading and body were misaligned previously.

BEFORE:

![before](https://user-images.githubusercontent.com/23148259/31307472-7359e496-ab82-11e7-9b73-83a22c521056.PNG)

AFTER:

![after](https://user-images.githubusercontent.com/23148259/31307477-7c2a0970-ab82-11e7-9918-307599e6bda3.PNG)

