### PR TITLE
Fixed body alignment in JFXDialogLayout

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXDialogLayout.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXDialogLayout.java
@@ -127,7 +127,7 @@ public class JFXDialogLayout extends StackPane {
         this.setStyle("-fx-text-fill: rgba(0, 0, 0, 0.87);");
         heading.setStyle("-fx-font-weight: BOLD;-fx-alignment: center-left;");
         heading.setPadding(new Insets(5, 0, 5, 0));
-        body.setStyle("-fx-pref-width: 400px;-fx-wrap-text: true;");
+        body.setStyle("-fx-pref-width: 400px;-fx-wrap-text: true; -fx-alignment: center-left");
         actions.setStyle("-fx-alignment: center-right ;");
         actions.setPadding(new Insets(10, 0, 0, 0));
     }


### PR DESCRIPTION
Added center-left alignment to nodes within the body. Heading and body were misaligned.

Before: 

![before](https://user-images.githubusercontent.com/23148259/31307549-25b9abf2-ab84-11e7-8068-131922598914.PNG)

After:

![after](https://user-images.githubusercontent.com/23148259/31307551-2f0b9508-ab84-11e7-8d98-c7400ec29f10.PNG)
