### PR TITLE
Displaying visual focus should be optional for JFXRadioButton and JFXToggleButton

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXRadioButton.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXRadioButton.java
@@ -20,6 +20,7 @@
 package com.jfoenix.controls;
 
 import com.jfoenix.skins.JFXRadioButtonSkin;
+import com.sun.javafx.css.converters.BooleanConverter;
 import com.sun.javafx.css.converters.ColorConverter;
 import javafx.css.*;
 import javafx.scene.control.Control;
@@ -126,6 +127,25 @@ public class JFXRadioButton extends RadioButton {
         this.unSelectedColorProperty().set(unSelectedColor);
     }
 
+    /**
+     * Disable the visual indicator for focus
+     */
+    private StyleableBooleanProperty disableVisualFocus = new SimpleStyleableBooleanProperty(StyleableProperties.DISABLE_VISUAL_FOCUS,
+        JFXRadioButton.this,
+        "disableVisualFocus",
+        false);
+
+    public final StyleableBooleanProperty disableVisualFocusProperty() {
+        return this.disableVisualFocus;
+    }
+
+    public final Boolean isDisableVisualFocus() {
+        return disableVisualFocus != null && this.disableVisualFocusProperty().get();
+    }
+
+    public final void setDisableVisualFocus(final Boolean disabled) {
+        this.disableVisualFocusProperty().set(disabled);
+    }
 
     private static class StyleableProperties {
         private static final CssMetaData<JFXRadioButton, Color> SELECTED_COLOR =
@@ -154,7 +174,19 @@ public class JFXRadioButton extends RadioButton {
                     return control.unSelectedColorProperty();
                 }
             };
+        private static final CssMetaData<JFXRadioButton, Boolean> DISABLE_VISUAL_FOCUS =
+            new CssMetaData<JFXRadioButton, Boolean>("-jfx-disable-visual-focus",
+                BooleanConverter.getInstance(), false) {
+                @Override
+                public boolean isSettable(JFXRadioButton control) {
+                    return control.disableVisualFocus == null || !control.disableVisualFocus.isBound();
+                }
 
+                @Override
+                public StyleableBooleanProperty getStyleableProperty(JFXRadioButton control) {
+                    return control.disableVisualFocusProperty();
+                }
+            };
         private static final List<CssMetaData<? extends Styleable, ?>> CHILD_STYLEABLES;
 
         static {
@@ -162,7 +194,8 @@ public class JFXRadioButton extends RadioButton {
                 new ArrayList<>(Control.getClassCssMetaData());
             Collections.addAll(styleables,
                 SELECTED_COLOR,
-                UNSELECTED_COLOR
+                UNSELECTED_COLOR,
+                DISABLE_VISUAL_FOCUS
             );
             CHILD_STYLEABLES = Collections.unmodifiableList(styleables);
         }

--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXToggleButton.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXToggleButton.java
@@ -20,6 +20,7 @@
 package com.jfoenix.controls;
 
 import com.jfoenix.skins.JFXToggleButtonSkin;
+import com.sun.javafx.css.converters.BooleanConverter;
 import com.sun.javafx.css.converters.PaintConverter;
 import javafx.css.*;
 import javafx.scene.control.Control;
@@ -220,6 +221,25 @@ public class JFXToggleButton extends ToggleButton {
         this.size.set(size);
     }
 
+    /**
+     * Disable the visual indicator for focus
+     */
+    private StyleableBooleanProperty disableVisualFocus = new SimpleStyleableBooleanProperty(StyleableProperties.DISABLE_VISUAL_FOCUS,
+        JFXToggleButton.this,
+        "disableVisualFocus",
+        false);
+
+    public final StyleableBooleanProperty disableVisualFocusProperty() {
+        return this.disableVisualFocus;
+    }
+
+    public final Boolean isDisableVisualFocus() {
+        return disableVisualFocus != null && this.disableVisualFocusProperty().get();
+    }
+
+    public final void setDisableVisualFocus(final Boolean disabled) {
+        this.disableVisualFocusProperty().set(disabled);
+    }
 
     private static class StyleableProperties {
         private static final CssMetaData<JFXToggleButton, Paint> TOGGLE_COLOR =
@@ -291,7 +311,19 @@ public class JFXToggleButton extends ToggleButton {
                     return control.sizeProperty();
                 }
             };
+        private static final CssMetaData<JFXToggleButton, Boolean> DISABLE_VISUAL_FOCUS =
+            new CssMetaData<JFXToggleButton, Boolean>("-jfx-disable-visual-focus",
+                BooleanConverter.getInstance(), false) {
+                @Override
+                public boolean isSettable(JFXToggleButton control) {
+                    return control.disableVisualFocus == null || !control.disableVisualFocus.isBound();
+                }
 
+                @Override
+                public StyleableBooleanProperty getStyleableProperty(JFXToggleButton control) {
+                    return control.disableVisualFocusProperty();
+                }
+            };
 
         private static final List<CssMetaData<? extends Styleable, ?>> CHILD_STYLEABLES;
 
@@ -303,7 +335,8 @@ public class JFXToggleButton extends ToggleButton {
                 TOGGLE_COLOR,
                 UNTOGGLE_COLOR,
                 TOGGLE_LINE_COLOR,
-                UNTOGGLE_LINE_COLOR
+                UNTOGGLE_LINE_COLOR,
+                DISABLE_VISUAL_FOCUS
             );
             CHILD_STYLEABLES = Collections.unmodifiableList(styleables);
         }

--- a/jfoenix/src/main/java/com/jfoenix/skins/JFXRadioButtonSkin.java
+++ b/jfoenix/src/main/java/com/jfoenix/skins/JFXRadioButtonSkin.java
@@ -83,12 +83,14 @@ public class JFXRadioButtonSkin extends RadioButtonSkin {
 
         // show focused state
         control.focusedProperty().addListener((o, oldVal, newVal) -> {
-            if (newVal) {
-                if (!getSkinnable().isPressed()) {
-                    rippler.showOverlay();
+            if(!control.disableVisualFocusProperty().get()) {
+                if (newVal) {
+                    if (!getSkinnable().isPressed()) {
+                        rippler.showOverlay();
+                    }
+                } else {
+                    rippler.hideOverlay();
                 }
-            } else {
-                rippler.hideOverlay();
             }
         });
         control.pressedProperty().addListener((o, oldVal, newVal) -> rippler.hideOverlay());

--- a/jfoenix/src/main/java/com/jfoenix/skins/JFXToggleButtonSkin.java
+++ b/jfoenix/src/main/java/com/jfoenix/skins/JFXToggleButtonSkin.java
@@ -110,12 +110,14 @@ public class JFXToggleButtonSkin extends ToggleButtonSkin {
             }
         });
         toggleButton.focusedProperty().addListener((o, oldVal, newVal) -> {
-            if (newVal) {
-                if (!getSkinnable().isPressed()) {
-                    rippler.showOverlay();
+            if(!toggleButton.isDisableVisualFocus()) {
+                if (newVal) {
+                    if (!getSkinnable().isPressed()) {
+                        rippler.showOverlay();
+                    }
+                } else {
+                    rippler.hideOverlay();
                 }
-            } else {
-                rippler.hideOverlay();
             }
         });
         toggleButton.pressedProperty().addListener((o, oldVal, newVal) -> rippler.hideOverlay());


### PR DESCRIPTION
This is issue is essentially the same as #471 but instead applied to JFXRadioButton and JFXToggleButton.