### PR TITLE
Make LoLPing link go to the github page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Feel free to submit your project info to the following <a href="mailto:developer
 
 # Projects using JFoenix
 * <a href="http://bcozy.org">BCozy</a>
-* Other small projects <a href="https://mayuso.itch.io/lolping-2">LOL ping</a>,
+* Other small projects <a href="https://github.com/mayuso/LoLPing2">LoLPing 2</a>,
 <a href="https://github.com/naeemkhan12/CurrencyConverter.git">Currency Converter</a>
 
 # Build


### PR DESCRIPTION
It makes more sense to me if the link goes to the github page instead of the itch.io page. I created LoLPing to learn about JavaFX and JFoenix, so I'd love to have people seeing my code and suggesting me how to improve it, because I am sure there's a lot to improve.