### PR TITLE
Add FXML Support for JFXNodesList

### DIFF
--- a/demo/src/main/java/demos/gui/sidemenu/SideMenuController.java
+++ b/demo/src/main/java/demos/gui/sidemenu/SideMenuController.java
@@ -78,6 +78,9 @@ public class SideMenuController {
     @ActionTrigger("scrollpane")
     private Label scrollpane;
     @FXML
+    @ActionTrigger("nodeslist")
+    private Label nodesList;
+    @FXML
     private JFXListView<Label> sideList;
 
     /**
@@ -122,6 +125,7 @@ public class SideMenuController {
         bindNodeToController(pickers, PickersController.class, contentFlow, contentFlowHandler);
         bindNodeToController(masonry, MasonryPaneController.class, contentFlow, contentFlowHandler);
         bindNodeToController(scrollpane, ScrollPaneController.class, contentFlow, contentFlowHandler);
+        bindNodeToController(nodesList, NodesListController.class, contentFlow, contentFlowHandler);
     }
 
     private void bindNodeToController(Node node, Class<?> controllerClass, Flow flow, FlowHandler flowHandler) {

--- a/demo/src/main/java/demos/gui/sidemenu/SideMenuController.java
+++ b/demo/src/main/java/demos/gui/sidemenu/SideMenuController.java
@@ -78,6 +78,9 @@ public class SideMenuController {
     @ActionTrigger("scrollpane")
     private Label scrollpane;
     @FXML
+    @ActionTrigger("chipview")
+    private Label chipview;
+    @FXML
     @ActionTrigger("nodeslist")
     private Label nodesList;
     @FXML
@@ -119,6 +122,7 @@ public class SideMenuController {
         bindNodeToController(slider, SliderController.class, contentFlow, contentFlowHandler);
         bindNodeToController(spinner, SpinnerController.class, contentFlow, contentFlowHandler);
         bindNodeToController(textfield, TextFieldController.class, contentFlow, contentFlowHandler);
+        bindNodeToController(chipview, ChipViewController.class, contentFlow, contentFlowHandler);
         bindNodeToController(togglebutton, ToggleButtonController.class, contentFlow, contentFlowHandler);
         bindNodeToController(popup, PopupController.class, contentFlow, contentFlowHandler);
         bindNodeToController(svgLoader, SVGLoaderController.class, contentFlow, contentFlowHandler);

--- a/demo/src/main/java/demos/gui/uicomponents/NodesListController.java
+++ b/demo/src/main/java/demos/gui/uicomponents/NodesListController.java
@@ -1,0 +1,46 @@
+package demos.gui.uicomponents;
+
+import com.jfoenix.controls.JFXButton;
+import com.jfoenix.controls.JFXNodesList;
+import io.datafx.controller.ViewController;
+import javafx.fxml.FXML;
+
+@ViewController(value = "/fxml/ui/NodesList.fxml", title = "Material Design Example")
+public class NodesListController {
+
+    @FXML
+    JFXNodesList nodesList;
+
+    @FXML
+    JFXButton newButton;
+    @FXML
+    JFXButton fileButton;
+    @FXML
+    JFXButton commentButton;
+    @FXML
+    JFXButton filterButton;
+
+
+    @FXML
+    public void onNewFile() {
+        System.out.println("New File");
+
+        //Close list
+        nodesList.animateList(false);
+    }
+
+    public void onNewComment() {
+        System.out.println("New Comment");
+
+        //Close list
+        nodesList.animateList(false);
+    }
+
+    public void onNewFilter() {
+        System.out.println("New Filter");
+
+        //Close list
+        nodesList.animateList(false);
+    }
+
+}

--- a/demo/src/main/resources/fxml/SideMenu.fxml
+++ b/demo/src/main/resources/fxml/SideMenu.fxml
@@ -27,5 +27,6 @@
         <Label fx:id="pickers">Pickers</Label>
         <Label fx:id="svgLoader">SVG Loader</Label>
         <Label fx:id="masonry">Masonry Layout</Label>
+        <Label fx:id="nodesList">Nodes List</Label>
     </JFXListView>
 </StackPane>

--- a/demo/src/main/resources/fxml/ui/NodesList.fxml
+++ b/demo/src/main/resources/fxml/ui/NodesList.fxml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import com.jfoenix.controls.JFXButton?>
+<?import com.jfoenix.controls.JFXNodesList?>
+<?import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.layout.StackPane?>
+
+<StackPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" stylesheets="@/css/jfoenix-components.css" xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" >
+    <children>
+        <JFXNodesList fx:id="nodesList" rotate="180.0" spacing="10" StackPane.alignment="BOTTOM_RIGHT">
+            <children>
+                <JFXButton fx:id="newButton" contentDisplay="GRAPHIC_ONLY" styleClass="animated-option-button">
+                    <graphic>
+                        <FontAwesomeIconView glyphName="PLUS" size="24" />
+                    </graphic>
+                </JFXButton>
+                <JFXButton fx:id="fileButton" contentDisplay="GRAPHIC_ONLY" onAction="#onNewFile" styleClass="animated-option-button">
+                    <graphic>
+                        <FontAwesomeIconView glyphName="FILE_TEXT" size="24" />
+                    </graphic>
+                </JFXButton>
+                <JFXButton fx:id="commentButton" contentDisplay="GRAPHIC_ONLY" onAction="#onNewComment" styleClass="animated-option-button">
+                    <graphic>
+                        <FontAwesomeIconView glyphName="COMMENT" size="24" />
+                    </graphic>
+                </JFXButton>
+                <JFXButton fx:id="filterButton" contentDisplay="GRAPHIC_ONLY" onAction="#onNewFilter" styleClass="animated-option-button">
+                    <graphic>
+                        <FontAwesomeIconView glyphName="FILTER" size="24" />
+                    </graphic>
+                </JFXButton>
+            </children>
+            <StackPane.margin>
+                <Insets bottom="10.0" right="10.0" />
+            </StackPane.margin>
+        </JFXNodesList>
+    </children>
+</StackPane>

--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXNodesList.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXNodesList.java
@@ -21,6 +21,9 @@ package com.jfoenix.controls;
 
 import javafx.animation.*;
 import javafx.animation.Animation.Status;
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
@@ -100,6 +103,20 @@ public class JFXNodesList extends VBox {
         setPickOnBounds(false);
         getStyleClass().add("jfx-nodes-list");
         setAlignment(Pos.TOP_CENTER);
+
+        //This is for children that get added in FXML
+        Platform.runLater(() -> {
+            if (getChildren().size() > 0) {
+                //Save the already-added children
+                ObservableList<Node> existingChildren = FXCollections.observableArrayList(getChildren());
+                //Remove all children from JFXNodesList
+                getChildren().removeAll(existingChildren);
+                //Add each child back properly
+                for (Node child : existingChildren) {
+                    this.addAnimatedNode((Region) child);
+                }
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
Allows the user to specify children for a JFXNodesList in FXML. See #613.

I wonder if the page in the main demo might be better named "Speed Dial", as per the Material Design Guidelines, (https://material.io/guidelines/components/buttons-floating-action-button.html#transitions-figure-caption-6).

What do you think?