### PR TITLE
fix close button design

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/transitions/hamburger/HamburgerBasicCloseTransition.java
+++ b/jfoenix/src/main/java/com/jfoenix/transitions/hamburger/HamburgerBasicCloseTransition.java
@@ -59,7 +59,7 @@ public class HamburgerBasicCloseTransition extends CachedTransition implements H
             .getMinY();
 
         double hypotenuse = Math.sqrt(Math.pow(burgerHeight, 2) + Math.pow(burgerWidth, 2));
-        double angle = (Math.toDegrees(Math.asin(burgerWidth / hypotenuse)) - 90) * -1;
+        double angle = (Math.toDegrees(Math.asin(burgerWidth / hypotenuse)) - 100) * -1;
         return new Timeline(
             new KeyFrame(
                 Duration.ZERO,

--- a/jfoenix/src/main/java/com/jfoenix/transitions/hamburger/HamburgerSlideCloseTransition.java
+++ b/jfoenix/src/main/java/com/jfoenix/transitions/hamburger/HamburgerSlideCloseTransition.java
@@ -89,7 +89,7 @@ public class HamburgerSlideCloseTransition extends CachedTransition implements H
             .getMinY();
 
         double hypotenuse = Math.sqrt(Math.pow(burgerHeight, 2) + Math.pow(burgerWidth, 2));
-        double angle = Math.toDegrees(Math.asin(burgerWidth / hypotenuse)) + 90;
+        double angle = Math.toDegrees(Math.asin(burgerWidth / hypotenuse)) + 80;
 
         return new Timeline(
             new KeyFrame(


### PR DESCRIPTION
Hello, I just updated the design of the close icon in the hamburger transitions.

Old version :
<img width="40" alt="capture d ecran 2018-09-20 a 13 38 13" src="https://user-images.githubusercontent.com/10800948/45817813-2d175480-bce0-11e8-8f43-723e8824aa7c.png">

Updated version :
<img width="37" alt="capture d ecran 2018-09-20 a 13 37 53" src="https://user-images.githubusercontent.com/10800948/45817812-2d175480-bce0-11e8-97d0-571541dd3052.png">

Current material design version :
<img width="50" alt="capture d ecran 2018-09-20 a 13 38 20" src="https://user-images.githubusercontent.com/10800948/45817811-2d175480-bce0-11e8-8eaf-1814d6e1b817.png">

Let me know if there is any problem 😃 