### PR TITLE
fixed #833 Memory leaks using JFXMasonryPane

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXMasonryPane.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXMasonryPane.java
@@ -66,6 +66,11 @@ public class JFXMasonryPane extends Pane {
         if (change.next()) {
             // flag dirty boxes
             dirtyBoxes = true;
+            
+            // clean removed child nodes from animationMap
+            for (Node removedNode : change.getRemoved()) {
+                animationMap.remove(removedNode);
+            }
         }
         clearLayout();
         requestLayout();


### PR DESCRIPTION

I have implemented the fix discussed on #833.
JFXMasonryPane `animationMap` attribute is now correctly cleared when childs are removed.