### PR TITLE
`JFXTimePicker.setIs24HourView` to `JFXTimePicker.set24HourView`

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXTimePicker.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXTimePicker.java
@@ -152,10 +152,9 @@ public class JFXTimePicker extends ComboBoxBase<LocalTime> implements IFXValidat
         return _24HourViewProperty().get();
     }
 
-    public final void setIs24HourView(final boolean value) {
+    public final void set24HourView(final boolean value) {
         _24HourViewProperty().setValue(value);
     }
-
 
     /**
      * The editor for the JFXTimePicker.


### PR DESCRIPTION
I believe this is the right format. It would also allow for Kotlin interoperability (e.g.: `timePicker.is24HourView = true`).