### PR TITLE
Final JFXTemplateAnimation fixes.

### DIFF
--- a/demo/src/main/java/demos/components/AnimationTemplateDemo.java
+++ b/demo/src/main/java/demos/components/AnimationTemplateDemo.java
@@ -6,6 +6,7 @@ import com.jfoenix.transitions.template.JFXAnimationTemplate;
 import com.jfoenix.transitions.template.JFXTemplateBuilder;
 import javafx.animation.Interpolator;
 import javafx.animation.Timeline;
+import javafx.animation.Transition;
 import javafx.application.Application;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.StringBinding;
@@ -82,45 +83,36 @@ public class AnimationTemplateDemo extends Application {
           .config(b -> b.duration(Duration.seconds(1.3)).interpolator(Interpolator.EASE_BOTH));
 
   // For CSS see: https://github.com/daneden/animate.css/blob/master/source/specials/hinge.css
-  private static final JFXTemplateBuilder<Node> HINGE =
-      JFXAnimationTemplate.create()
-          .from()
-          .action(
-              b ->
-                  b.withAnimationObject(Rotate.class, "rotate")
-                      .target(Rotate::angleProperty)
-                      .endValue(0))
-          .percent(20, 60)
-          .action(
-              b ->
-                  b.withAnimationObject(Rotate.class, "rotate")
-                      .target(Rotate::angleProperty)
-                      .endValue(80))
-          .percent(40, 80)
-          .action(
-              b ->
-                  b.withAnimationObject(Rotate.class, "rotate")
-                      .target(Rotate::angleProperty)
-                      .endValue(60))
-          .action(b -> b.target(Node::opacityProperty).endValue(1))
-          .action(b -> b.target(Node::translateYProperty).endValue(0))
-          .to()
-          .action(b -> b.target(Node::opacityProperty).endValue(0))
-          .action(b -> b.target(Node::translateYProperty).endValue(700))
-          // just for resetting the animation.
-          .action(
-              b ->
-                  b.onFinish(
-                      (node, actionEvent) -> {
-                        node.setTranslateY(0);
-                        node.setOpacity(1);
-                      }))
-          // just for resetting the animation.
-          .action(
-              b ->
-                  b.withAnimationObject(Rotate.class, "rotate")
-                      .onFinish((rotate, actionEvent) -> rotate.setAngle(0)))
-          .config(b -> b.duration(Duration.seconds(2)).interpolator(Interpolator.EASE_BOTH));
+  private static JFXTemplateBuilder<Node> hinge() {
+    Rotate rotate = new Rotate(0, 0, 0);
+    return JFXAnimationTemplate.create()
+        .from()
+        // One execution for init behaviour.
+        .action(
+            b -> b.executions(1).onFinish((node, actionEvent) -> node.getTransforms().add(rotate)))
+        .percent(1)
+        .action(b -> b.target(rotate.angleProperty()).endValue(0))
+        .percent(20, 60)
+        .action(b -> b.target(rotate.angleProperty()).endValue(80))
+        .percent(40, 80)
+        .action(b -> b.target(rotate.angleProperty()).endValue(60))
+        .action(b -> b.target(Node::opacityProperty).endValue(1))
+        .action(b -> b.target(Node::translateYProperty).endValue(0))
+        .to()
+        .action(b -> b.target(Node::opacityProperty).endValue(0))
+        .action(b -> b.target(Node::translateYProperty).endValue(700))
+        // just for resetting the animation.
+        .action(
+            b ->
+                b.onFinish(
+                    (node, actionEvent) -> {
+                      rotate.setAngle(0);
+                      node.setTranslateY(0);
+                      node.setOpacity(1);
+                    }))
+        // just for resetting the animation.
+        .config(b -> b.duration(Duration.seconds(2)).interpolator(Interpolator.EASE_BOTH));
+  }
 
   // For CSS see:
   // https://github.com/daneden/animate.css/blob/master/source/attention_seekers/wobble.css
@@ -190,37 +182,37 @@ public class AnimationTemplateDemo extends Application {
           .from()
           .action(
               b ->
-                  b.withAnimationObject(Node.class, "firstRow", "secondRow", "thirdRow")
+                  b.withAnimationObject("firstRow", "secondRow", "thirdRow")
                       .onFinish((node, actionEvent) -> node.setVisible(false)))
           .percent(50)
           .action(
               b ->
-                  b.withAnimationObject(Node.class, "firstRow")
+                  b.withAnimationObject("firstRow")
                       .onFinish((node, actionEvent) -> BOUNCE_IN_UP.build(node).play()))
           .percent(51)
           .action(
               b ->
-                  b.withAnimationObject(Node.class, "firstRow")
+                  b.withAnimationObject("firstRow")
                       .onFinish((node, actionEvent) -> node.setVisible(true)))
           .percent(62)
           .action(
               b ->
-                  b.withAnimationObject(Node.class, "secondRow")
+                  b.withAnimationObject("secondRow")
                       .onFinish((node, actionEvent) -> BOUNCE_IN_UP.build(node).play()))
           .percent(63)
           .action(
               b ->
-                  b.withAnimationObject(Node.class, "secondRow")
+                  b.withAnimationObject("secondRow")
                       .onFinish((node, actionEvent) -> node.setVisible(true)))
           .percent(68)
           .action(
               b ->
-                  b.withAnimationObject(Node.class, "thirdRow")
+                  b.withAnimationObject("thirdRow")
                       .onFinish((node, actionEvent) -> BOUNCE_IN_UP.build(node).play()))
           .percent(69)
           .action(
               b ->
-                  b.withAnimationObject(Node.class, "thirdRow")
+                  b.withAnimationObject("thirdRow")
                       .onFinish((node, actionEvent) -> node.setVisible(true)))
           .config(b -> b.duration(Duration.millis(700)));
 
@@ -374,11 +366,8 @@ public class AnimationTemplateDemo extends Application {
     animations.put("Tada", TADA.build(header));
     animations.put("BounceIn Up", BOUNCE_IN_UP.build(header));
     animations.put("Wobble", WOBBLE.build(header));
+    animations.put("Hinge", hinge().build(header));
 
-    Rotate rotate = new Rotate(0, 0, 0);
-    header.getTransforms().add(rotate);
-    animations.put(
-        "Hinge", HINGE.build(b -> b.defaultObject(header).namedObject("rotate", rotate)));
     Group body = createBody(animations);
     body.setVisible(false);
 

--- a/demo/src/main/java/demos/components/AnimationTemplateDemo.java
+++ b/demo/src/main/java/demos/components/AnimationTemplateDemo.java
@@ -6,7 +6,6 @@ import com.jfoenix.transitions.template.JFXAnimationTemplate;
 import com.jfoenix.transitions.template.JFXTemplateBuilder;
 import javafx.animation.Interpolator;
 import javafx.animation.Timeline;
-import javafx.animation.Transition;
 import javafx.application.Application;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.StringBinding;

--- a/jfoenix/src/main/java/com/jfoenix/transitions/template/ConditionalInterpolator.java
+++ b/jfoenix/src/main/java/com/jfoenix/transitions/template/ConditionalInterpolator.java
@@ -1,0 +1,67 @@
+package com.jfoenix.transitions.template;
+
+import javafx.animation.Interpolator;
+import javafx.beans.value.WritableValue;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Intercepts a {@link Interpolator} with a defined condition.
+ *
+ * @author Marcel Schlegel (schlegel11)
+ * @version 1.0
+ * @since 2018-10-24
+ */
+public class ConditionalInterpolator extends Interpolator {
+
+  private final Interpolator interpolator;
+  private final WritableValue<Object> target;
+  private final BooleanSupplier condition;
+
+  public ConditionalInterpolator(
+      Interpolator interpolator, WritableValue<Object> target, BooleanSupplier condition) {
+    this.interpolator = interpolator;
+    this.target = target;
+    this.condition = condition;
+  }
+
+  @Override
+  public Object interpolate(Object startValue, Object endValue, double fraction) {
+    return condition.getAsBoolean()
+        ? interpolator.interpolate(startValue, endValue, fraction)
+        : target.getValue();
+  }
+
+  @Override
+  public boolean interpolate(boolean startValue, boolean endValue, double fraction) {
+    return condition.getAsBoolean()
+        ? interpolator.interpolate(startValue, endValue, fraction)
+        : (boolean) target.getValue();
+  }
+
+  @Override
+  public double interpolate(double startValue, double endValue, double fraction) {
+    return condition.getAsBoolean()
+        ? interpolator.interpolate(startValue, endValue, fraction)
+        : (double) target.getValue();
+  }
+
+  @Override
+  public int interpolate(int startValue, int endValue, double fraction) {
+    return condition.getAsBoolean()
+        ? interpolator.interpolate(startValue, endValue, fraction)
+        : (int) target.getValue();
+  }
+
+  @Override
+  public long interpolate(long startValue, long endValue, double fraction) {
+    return condition.getAsBoolean()
+        ? interpolator.interpolate(startValue, endValue, fraction)
+        : (long) target.getValue();
+  }
+
+  @Override
+  protected double curve(double t) {
+    return 0;
+  }
+}

--- a/jfoenix/src/main/java/com/jfoenix/transitions/template/ConditionalInterpolator.java
+++ b/jfoenix/src/main/java/com/jfoenix/transitions/template/ConditionalInterpolator.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.jfoenix.transitions.template;
 
 import javafx.animation.Interpolator;

--- a/jfoenix/src/main/java/com/jfoenix/transitions/template/JFXAnimationTemplate.java
+++ b/jfoenix/src/main/java/com/jfoenix/transitions/template/JFXAnimationTemplate.java
@@ -26,6 +26,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
+ * Class which represents a general {@link JFXAnimationTemplate}. <br>
+ * This class is responsible for providing methods where it's possible to build a CSS like
+ * structured animation.
+ *
  * @author Marcel Schlegel (schlegel11)
  * @version 1.0
  * @since 2018-09-18
@@ -56,10 +60,27 @@ public class JFXAnimationTemplate<N> implements JFXTemplateConfig<N>, JFXTemplat
     this.animationObjectType = animationObjectType;
   }
 
+  /**
+   * Create a {@link JFXTemplateProcess} with a specific default animation type.<br>
+   * The default animation objects with this type are set later in the {@link
+   * JFXTemplateBuilder#build(Object)} method.<br>
+   * These objects are generally used in {@link JFXTemplateAction#action(Function)} methods.
+   *
+   * @param animationObjectType a specific animation object type.
+   * @param <N> the specific type.
+   * @return a {@link JFXTemplateProcess} instance.
+   */
   public static <N> JFXTemplateProcess<N> create(Class<N> animationObjectType) {
     return new JFXAnimationTemplate<>(animationObjectType);
   }
 
+  /**
+   * Same method as {@link #create(Class)} but with the default type {@link Node}. This type is a
+   * general default type in a {@link JFXAnimationTemplate}.
+   *
+   * @see #create(Class)
+   * @return a {@link JFXTemplateProcess} instance.
+   */
   public static JFXTemplateProcess<Node> create() {
     return create(Node.class);
   }

--- a/jfoenix/src/main/java/com/jfoenix/transitions/template/JFXAnimationTemplateConfig.java
+++ b/jfoenix/src/main/java/com/jfoenix/transitions/template/JFXAnimationTemplateConfig.java
@@ -27,6 +27,11 @@ import javafx.util.Duration;
 import java.util.function.Supplier;
 
 /**
+ * Class which represents a builder and the configuration of an animation. The configuration methods
+ * are based on the methods of a {@link javafx.animation.Timeline}.<br>
+ * It is possible that not all methods supported because the specific implementation of an animation
+ * can diverge from a general {@link javafx.animation.Timeline} implementation.
+ *
  * @author Marcel Schlegel (schlegel11)
  * @version 1.0
  * @since 2018-09-22
@@ -95,64 +100,159 @@ public class JFXAnimationTemplateConfig {
 
     private Builder() {}
 
+    /**
+     * The total {@link Duration} of this animation.
+     *
+     * @param duration the animation {@link Duration}.
+     * @return the {@link Builder} instance.
+     */
     public Builder duration(Duration duration) {
       return duration(() -> duration);
     }
 
+    /**
+     * The lazy version of {@link #duration(Duration)} which is computed when the {@link
+     * JFXAnimationTemplateConfig} is build.
+     *
+     * @param durationSupplier the animation {@link Duration} {@link Supplier}.
+     * @return the {@link Builder} instance.
+     */
     public Builder duration(Supplier<Duration> durationSupplier) {
       this.durationSupplier = durationSupplier;
       return this;
     }
 
+    /**
+     * Defines the number of cycles in this animation.
+     *
+     * @param cycleCount the number of cycles.
+     * @return the {@link Builder} instance.
+     */
     public Builder cycleCount(int cycleCount) {
       return cycleCount(() -> cycleCount);
     }
 
+    /**
+     * The lazy version of {@link #cycleCount(int)} which is computed when the {@link
+     * JFXAnimationTemplateConfig} is build.
+     *
+     * @see #cycleCount(int)
+     * @param cycleCountSupplier the number of cycles {@link Supplier}.
+     * @return the {@link Builder} instance.
+     */
     public Builder cycleCount(Supplier<Integer> cycleCountSupplier) {
       this.cycleCountSupplier = cycleCountSupplier;
       return this;
     }
 
+    /**
+     * A {@link Animation#INDEFINITE} count of cycles in this animation.
+     *
+     * @return the {@link Builder} instance.
+     */
     public Builder infiniteCycle() {
       return cycleCount(Animation.INDEFINITE);
     }
 
+    /**
+     * After the first cycle the animation is played backwards and after this again forwards.
+     *
+     * @param reverse the reverse boolean.
+     * @return the {@link Builder} instance.
+     */
     public Builder autoReverse(boolean reverse) {
       return autoReverse(() -> reverse);
     }
 
+    /**
+     * The lazy version of {@link #autoReverse(boolean)} which is computed when the {@link
+     * JFXAnimationTemplateConfig} is build.
+     *
+     * @see #autoReverse(boolean)
+     * @param reverseSupplier the reverse boolean {@link Supplier}.
+     * @return the {@link Builder} instance.
+     */
     public Builder autoReverse(Supplier<Boolean> reverseSupplier) {
       this.autoReverseSupplier = reverseSupplier;
       return this;
     }
 
+    /**
+     * The global {@link Interpolator} which is set to all {@link JFXTemplateAction}s without a
+     * defined {@link Interpolator} with {@link
+     * JFXAnimationTemplateAction.Builder#interpolator(Interpolator)}.
+     *
+     * @param interpolator the global {@link Interpolator}.
+     * @return the {@link Builder} instance.
+     */
     public Builder interpolator(Interpolator interpolator) {
       return interpolator(() -> interpolator);
     }
 
+    /**
+     * The lazy version of {@link #interpolator(Interpolator)} which is computed when the {@link
+     * JFXAnimationTemplateConfig} is build.
+     *
+     * @see #interpolator(Interpolator)
+     * @param interpolatorSupplier the global {@link Interpolator} {@link Supplier}.
+     * @return the {@link Builder} instance.
+     */
     public Builder interpolator(Supplier<Interpolator> interpolatorSupplier) {
       this.interpolatorSupplier = interpolatorSupplier;
       return this;
     }
 
+    /**
+     * Delays the start of an animation.
+     *
+     * @param delay the delay {@link Duration}.
+     * @return the {@link Builder} instance.
+     */
     public Builder delay(Duration delay) {
       return delay(() -> delay);
     }
 
+    /**
+     * The lazy version of {@link #delay(Duration)} which is computed when the {@link
+     * JFXAnimationTemplateConfig} is build.
+     *
+     * @see #delay(Duration)
+     * @param delaySupplier the delay {@link Duration} {@link Supplier}.
+     * @return the {@link Builder} instance.
+     */
     public Builder delay(Supplier<Duration> delaySupplier) {
       this.delaySupplier = delaySupplier;
       return this;
     }
 
+    /**
+     * Defines the direction/speed at which the animation is expected to be played.
+     *
+     * @param rate the animation rate.
+     * @return the {@link Builder} instance.
+     */
     public Builder rate(double rate) {
       return rate(() -> rate);
     }
 
+    /**
+     * The lazy version of {@link #rate(double)} which is computed when the {@link
+     * JFXAnimationTemplateConfig} is build.
+     *
+     * @param rateSupplier the animation rate {@link Supplier}.
+     * @return the {@link Builder} instance.
+     */
     public Builder rate(Supplier<Double> rateSupplier) {
       this.rateSupplier = rateSupplier;
       return this;
     }
 
+    /**
+     * The action to be executed at the conclusion of this animation.
+     *
+     * @param onFinish the finish {@link EventHandler}.
+     * @return the {@link Builder} instance.
+     */
     public Builder onFinish(EventHandler<ActionEvent> onFinish) {
       this.onFinish = onFinish;
       return this;


### PR DESCRIPTION
This should be the last fixes for now :wink: 
I fixed the the behaviour of the "animateWhen" method.
The problem was that I check the "animateWhen" condition only at build time of the JFXAnimationTemplate so it was more a "buildWhen" conditon :wink: 
For this purpose the ConditionalInterpolator was added which intercepts a Interpolator instance with a condition and can be used with any implementation which uses Interpolators for it's key values.

Furthermore a "executions" method was add where a number of executions for an action can be defined.
This can be used for e.g. init behaviour for an animation.

Greetings