### PR TITLE
Use the default Locale in TimePicker StringConverter

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXTimePicker.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXTimePicker.java
@@ -140,7 +140,7 @@ public class JFXTimePicker extends ComboBoxBase<LocalTime> implements IFXValidat
     }
 
     private StringConverter<LocalTime> defaultConverter = new LocalTimeStringConverter(FormatStyle.SHORT,
-        Locale.ENGLISH);
+        Locale.getDefault());
 
     private BooleanProperty _24HourView = new SimpleBooleanProperty(false);
 


### PR DESCRIPTION
Using the default Local instead hard coded to Locale.ENGLISH.

If the client has set default Locale to UK, it will show AM/PM in TimePicker, because the Locale is hard coded to ENGLISH.