### PR TITLE
Fix Chinese environment week display incorrectly again

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/skins/JFXDatePickerContent.java
+++ b/jfoenix/src/main/java/com/jfoenix/skins/JFXDatePickerContent.java
@@ -579,8 +579,9 @@ public class JFXDatePickerContent extends VBox {
         for (int i = 0; i < daysPerWeek; i++) {
             String name = weekDayNameFormatter.withLocale(getLocale()).format(date.plus(i, DAYS));
             // Fix Chinese environment week display incorrectly
+            // Take the last character of the Chinese weekday names
             if (weekDayNameFormatter.getLocale() == java.util.Locale.CHINA) {
-                name = name.substring(2, 3).toUpperCase();
+                name = name.substring(name.length() - 1).toUpperCase();
             } else {
                 name = name.substring(0, 1).toUpperCase();
             }


### PR DESCRIPTION
Take the last character of the Chinese weekday names instead of the third character #893 