### PR TITLE
Prevent error when reopening non-closed JFXDialog

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXDialog.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXDialog.java
@@ -306,8 +306,10 @@ public class JFXDialog extends StackPane {
             tempImage.setCacheHint(CacheHint.SPEED);
             dialogContainer.getChildren().setAll(tempImage, this);
         } else {
-            tempContent = null;
-            dialogContainer.getChildren().add(this);
+        	//prevent error if opening an already opened dialog
+        	dialogContainer.getChildren().remove(this);
+        	tempContent = null;
+        	dialogContainer.getChildren().add(this);
         }
 
         if (animation != null) {


### PR DESCRIPTION
Without the removal from the container, this will cause an error when opening a dialog that hasn't been closed already