### PR TITLE
Fix for wrong datepicker year jump

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/skins/JFXDatePickerContent.java
+++ b/jfoenix/src/main/java/com/jfoenix/skins/JFXDatePickerContent.java
@@ -763,7 +763,8 @@ public class JFXDatePickerContent extends VBox {
     }
 
     private void goToDayCell(DateCell dateCell, int offset, ChronoUnit unit, boolean focusDayCell) {
-        goToDate(dayCellDate(dateCell).plus(offset, unit), focusDayCell);
+        YearMonth yearMonth = selectedYearMonth.get().plus(offset, unit);
+        goToDate(dayCellDate(dateCell).plus(offset, unit).withYear(yearMonth.getYear()), focusDayCell);
     }
 
     private void goToDate(LocalDate date, boolean focusDayCell) {


### PR DESCRIPTION
Hi,
regarding the issue #921 I tried a little bit around with the datepicker. 
I'm not sure if this is the solution for the issue but I think it is actual an issue :wink:

If a december date gets picked in the datepicker and afterwards the year is changed and you slide to the next month which is the next years january the wrong year is selected:

![no-fix](https://user-images.githubusercontent.com/5841076/51441395-55847f00-1cd1-11e9-8a5e-801923d9ad50.gif)

The selectedYearMonth property of the datepicker contains always the right year so I set this year to the offset of dateCell.
Fixed:

![with-fix](https://user-images.githubusercontent.com/5841076/51441419-a3998280-1cd1-11e9-8869-900ad2181b51.gif)

Greetings

