### PR TITLE
Fix JFXDecorator's getGraphic

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/controls/JFXDecorator.java
+++ b/jfoenix/src/main/java/com/jfoenix/controls/JFXDecorator.java
@@ -636,7 +636,7 @@ public class JFXDecorator extends VBox {
         graphic = node;
     }
 
-    public Node getGraphic(Node node) {
+    public Node getGraphic() {
         return graphic;
     }
 }


### PR DESCRIPTION
My best guess is that someone tried to copy and reuse `setGraphic`'s signature, but forgot to remove it's `Node`, parameter. This just gets rid of that.