### PR TITLE
Null check for RegExValidator

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/validation/RegexValidator.java
+++ b/jfoenix/src/main/java/com/jfoenix/validation/RegexValidator.java
@@ -63,7 +63,9 @@ public class RegexValidator extends ValidatorBase {
 
     private void evalTextInputField() {
         TextInputControl textField = (TextInputControl) srcControl.get();
-        if (regexPatternCompiled.matcher(textField.getText()).matches()) {
+        String text = (textField.getText() == null) ? "" : textField.getText(); // Treat null like empty string
+
+        if (regexPatternCompiled.matcher(text).matches()) {
             hasErrors.set(false);
         } else {
             hasErrors.set(true);


### PR DESCRIPTION
Matcher doesn't like nulls. If the text is null, we'll treat it like an empty string.