### PR TITLE
Support tooltips for non-controls in ValidatorBase and add documentation

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/validation/base/ValidatorBase.java
+++ b/jfoenix/src/main/java/com/jfoenix/validation/base/ValidatorBase.java
@@ -38,7 +38,10 @@ import java.util.function.Supplier;
 public abstract class ValidatorBase extends Parent {
 
     /**
-     * this style class will be activated when a validation error occurs
+     * This {@link PseudoClass} will be activated when a validation error occurs.
+     * <p>
+     * Some components have default styling for this pseudo class. See {@code jfx-text-field.css}
+     * and {@code jfx-combo-box.css} for examples.
      */
     public static final PseudoClass PSEUDO_CLASS_ERROR = PseudoClass.getPseudoClass("error");
 
@@ -95,7 +98,9 @@ public abstract class ValidatorBase extends Parent {
     }
 
     /**
-     * will validate the source control
+     * Will validate the source control.
+     * <p>
+     * Calls {@link #eval()} and then {@link #onEval()}.
      */
     public void validate() {
         eval();
@@ -103,12 +108,18 @@ public abstract class ValidatorBase extends Parent {
     }
 
     /**
-     * will evaluate the validation condition once calling validate method
+     * Should evaluate the validation condition and set {@link #hasErrors} to true or false. It should
+     * be true when the value is invalid (it has errors) and false when the value is valid (no errors).
+     * <p>
+     * This method is fired once {@link #validate()} is called.
      */
     protected abstract void eval();
 
     /**
-     * this method will update the source control after evaluating the validation condition
+     * This method will update the source control after evaluating the validation condition (see {@link #eval()}).
+     * <p>
+     * If the validator isn't "passing" the {@link #PSEUDO_CLASS_ERROR :error} pseudoclass is applied to the
+     * {@link #srcControl}.
      */
     protected void onEval() {
         Node control = getSrcControl();
@@ -142,7 +153,7 @@ public abstract class ValidatorBase extends Parent {
 
     /**
      * The {@link Control}/{@link Node} that the validator is checking the value of.
-     *
+     * <p>
      * Supports {@link Node}s because not all things that need validating are {@link Control}s.
      */
     protected SimpleObjectProperty<Node> srcControl = new SimpleObjectProperty<>();
@@ -246,12 +257,14 @@ public abstract class ValidatorBase extends Parent {
     public void setMessage(String msg) {
         this.message.set(msg);
     }
+
     /**
      * @see #message
      */
     public String getMessage() {
         return this.message.get();
     }
+
     /**
      * @see #message
      */

--- a/jfoenix/src/main/java/com/jfoenix/validation/base/ValidatorBase.java
+++ b/jfoenix/src/main/java/com/jfoenix/validation/base/ValidatorBase.java
@@ -19,6 +19,8 @@
 
 package com.jfoenix.validation.base;
 
+import com.jfoenix.validation.RegexValidator;
+import com.jfoenix.validation.RequiredFieldValidator;
 import javafx.beans.property.*;
 import javafx.css.PseudoClass;
 import javafx.scene.Node;
@@ -70,11 +72,21 @@ public abstract class ValidatorBase extends Parent {
      */
     private Tooltip errorTooltip = null;
 
+    /**
+     * @see #ValidatorBase()
+     * @param message will be set as the validator's {@link #message}.
+     */
     public ValidatorBase(String message) {
         this();
         this.setMessage(message);
     }
 
+    /**
+     * When creating a new validator you need to define the validation condition by implementing {@link #eval()}.
+     * <p>
+     * For examples of how you might implement it, see {@link RequiredFieldValidator} and
+     * {@link RegexValidator}.
+     */
     public ValidatorBase() {
         parentProperty().addListener((o, oldVal, newVal) -> parentChanged());
         errorTooltip = new Tooltip();

--- a/jfoenix/src/main/java/com/jfoenix/validation/base/ValidatorBase.java
+++ b/jfoenix/src/main/java/com/jfoenix/validation/base/ValidatorBase.java
@@ -140,23 +140,37 @@ public abstract class ValidatorBase extends Parent {
     // Properties
     ///////////////////////////////////////////////////////////////////////////
 
-    /***** srcControl *****/
+    /**
+     * The {@link Control}/{@link Node} that the validator is checking the value of.
+     *
+     * Supports {@link Node}s because not all things that need validating are {@link Control}s.
+     */
     protected SimpleObjectProperty<Node> srcControl = new SimpleObjectProperty<>();
 
+    /**
+     * @see #srcControl
+     */
     public void setSrcControl(Node srcControl) {
         this.srcControl.set(srcControl);
     }
 
+    /**
+     * @see #srcControl
+     */
     public Node getSrcControl() {
         return this.srcControl.get();
     }
 
+    /**
+     * @see #srcControl
+     */
     public ObjectProperty<Node> srcControlProperty() {
         return this.srcControl;
     }
 
 
     /***** src *****/
+    // TODO: 6/11/2019 Describe what this is for and when someone should set/override it.
     protected SimpleStringProperty src = new SimpleStringProperty() {
         @Override
         protected void invalidated() {
@@ -164,14 +178,23 @@ public abstract class ValidatorBase extends Parent {
         }
     };
 
+    /**
+     * @see #src
+     */
     public void setSrc(String src) {
         this.src.set(src);
     }
 
+    /**
+     * @see #src
+     */
     public String getSrc() {
         return this.src.get();
     }
 
+    /**
+     * @see #src
+     */
     public StringProperty srcProperty() {
         return this.src;
     }
@@ -202,6 +225,7 @@ public abstract class ValidatorBase extends Parent {
     public ReadOnlyBooleanProperty hasErrorsProperty() {
         return hasErrors.getReadOnlyProperty();
     }
+
 
     /**
      * The error message to display when the validator is <em>not</em> "passing."
@@ -234,6 +258,7 @@ public abstract class ValidatorBase extends Parent {
     public StringProperty messageProperty() {
         return this.message;
     }
+
 
     /***** Icon *****/
     protected SimpleObjectProperty<Supplier<Node>> iconSupplier = new SimpleObjectProperty<Supplier<Node>>() {

--- a/jfoenix/src/main/java/com/jfoenix/validation/base/ValidatorBase.java
+++ b/jfoenix/src/main/java/com/jfoenix/validation/base/ValidatorBase.java
@@ -73,8 +73,8 @@ public abstract class ValidatorBase extends Parent {
     private Tooltip errorTooltip = null;
 
     /**
-     * @see #ValidatorBase()
      * @param message will be set as the validator's {@link #message}.
+     * @see #ValidatorBase()
      */
     public ValidatorBase(String message) {
         this();
@@ -132,6 +132,9 @@ public abstract class ValidatorBase extends Parent {
      * <p>
      * If the validator isn't "passing" the {@link #PSEUDO_CLASS_ERROR :error} pseudoclass is applied to the
      * {@link #srcControl}.
+     * <p>
+     * Applies the {@link #PSEUDO_CLASS_ERROR :error} pseudo class and the {@link #errorTooltip} to
+     * the {@link #srcControl}.
      */
     protected void onEval() {
         Node control = getSrcControl();
@@ -145,6 +148,13 @@ public abstract class ValidatorBase extends Parent {
                 }
                 errorTooltip.setText(getMessage());
                 ((Control) control).setTooltip(errorTooltip);
+            } else {
+                Tooltip installedTooltip = (Tooltip) control.getProperties().get(TOOLTIP_PROP_KEY);
+                if (installedTooltip != null && !installedTooltip.getStyleClass().contains(ERROR_TOOLTIP_STYLE_CLASS)) {
+                    savedTooltip = installedTooltip;
+                }
+
+                Tooltip.install(control, errorTooltip);
             }
         } else {
             if (control instanceof Control) {
@@ -153,9 +163,16 @@ public abstract class ValidatorBase extends Parent {
                     || (controlTooltip == null && savedTooltip != null)) {
                     ((Control) control).setTooltip(savedTooltip);
                 }
-                savedTooltip = null;
+            } else {
+                Tooltip installedTooltip = (Tooltip) control.getProperties().get(TOOLTIP_PROP_KEY);
+                if ((installedTooltip != null && installedTooltip.getStyleClass().contains(ERROR_TOOLTIP_STYLE_CLASS))
+                    || (installedTooltip == null && savedTooltip != null)) {
+                    Tooltip.install(control, savedTooltip);
+                }
             }
-            control.pseudoClassStateChanged(PSEUDO_CLASS_ERROR, false);
+
+            savedTooltip = null; // Forget about saved tooltip
+            control.pseudoClassStateChanged(PSEUDO_CLASS_ERROR, false); // Deactivate pseudo class
         }
     }
 

--- a/jfoenix/src/main/java/com/jfoenix/validation/base/ValidatorBase.java
+++ b/jfoenix/src/main/java/com/jfoenix/validation/base/ValidatorBase.java
@@ -45,6 +45,7 @@ public abstract class ValidatorBase extends Parent {
     /**
      * When using {@code Tooltip.install(node, tooltip)}, the given tooltip is stored in the Node's properties
      * under this key.
+     *
      * @see Tooltip#install(Node, Tooltip)
      */
     private static final String TOOLTIP_PROP_KEY = "javafx.scene.control.Tooltip";
@@ -77,11 +78,9 @@ public abstract class ValidatorBase extends Parent {
         errorTooltip.getStyleClass().add(ERROR_TOOLTIP_STYLE_CLASS);
     }
 
-    /***************************************************************************
-     *                                                                         *
-     * Methods                                                                 *
-     *                                                                         *
-     **************************************************************************/
+    ///////////////////////////////////////////////////////////////////////////
+    // Methods
+    ///////////////////////////////////////////////////////////////////////////
 
     private void parentChanged() {
         updateSrcControl();
@@ -178,18 +177,38 @@ public abstract class ValidatorBase extends Parent {
     }
 
 
-    /***** hasErrors *****/
+    /**
+     * Tells whether the validator is "passing" or not.
+     * <p>
+     * In a validator's implementation of {@link #eval()}, if the value the validator is checking is invalid, it should
+     * set this to <em>true</em>. If the value is <em>valid</em>, it should set this to <em>false</em>.
+     * <p>
+     * When <em>hasErrors</em> is true, the validator will automatically apply the {@link #PSEUDO_CLASS_ERROR :error}
+     * pseudoclass to the {@link #srcControl}; the {@link #srcControl} will also have a {@link Tooltip} containing the
+     * {@link #message} applied to it (see {@link #errorTooltip}).
+     */
     protected ReadOnlyBooleanWrapper hasErrors = new ReadOnlyBooleanWrapper(false);
 
+    /**
+     * @see #hasErrors
+     */
     public boolean getHasErrors() {
         return hasErrors.get();
     }
 
+    /**
+     * @see #hasErrors
+     */
     public ReadOnlyBooleanProperty hasErrorsProperty() {
         return hasErrors.getReadOnlyProperty();
     }
 
-    /***** Message *****/
+    /**
+     * The error message to display when the validator is <em>not</em> "passing."
+     * <p>
+     * When {@link #hasErrors} is true, this message is displayed near the {@link #srcControl} (usually below);
+     * it's also displayed in a {@link Tooltip} applied to the {@link #srcControl} (see {@link #errorTooltip}).
+     */
     protected SimpleStringProperty message = new SimpleStringProperty() {
         @Override
         protected void invalidated() {
@@ -197,14 +216,21 @@ public abstract class ValidatorBase extends Parent {
         }
     };
 
+    /**
+     * @see #message
+     */
     public void setMessage(String msg) {
         this.message.set(msg);
     }
-
+    /**
+     * @see #message
+     */
     public String getMessage() {
         return this.message.get();
     }
-
+    /**
+     * @see #message
+     */
     public StringProperty messageProperty() {
         return this.message;
     }


### PR DESCRIPTION
In PR #1013, I did this same fix, but on an old version of `ValidatorBase`. This applies that same fix to the most recent version, instead.

While I was at it, I also added documentation for almost everything in `ValidatorBase`. Feel free to check my work, as I'm not the original author of the class—what I wrote is based on assumptions.