### PR TITLE
fixed OSGI manifest for Java9+

### DIFF
--- a/jfoenix/build.gradle
+++ b/jfoenix/build.gradle
@@ -78,7 +78,7 @@ jar {
 
     manifest {
         name = 'JFoenix'
-        instruction 'Bundle-RequiredExecutionEnvironment', 'JavaSE-1.9'
+        instruction 'Bundle-RequiredExecutionEnvironment', 'JavaSE-9'
         instruction 'Bundle-Description', 'JavaFX Material Design Library'
         instruction 'Import-Package', '!com.sun.*,!javafx.*, *'
         instruction 'Export-Package', '!com.jfoenix.android.*, *'


### PR DESCRIPTION
Starting with Java 9 you need to write without 1.
