### PR TITLE
Fix TabPane close button display problem

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/skins/JFXTabPaneSkin.java
+++ b/jfoenix/src/main/java/com/jfoenix/skins/JFXTabPaneSkin.java
@@ -1056,10 +1056,9 @@ public class JFXTabPaneSkin extends BehaviorSkinBase<TabPane, TabPaneBehavior> {
         }
 
         private boolean showCloseButton() {
-            return tab.isClosable() &&
-                   (getSkinnable().getTabClosingPolicy().equals(TabPane.TabClosingPolicy.ALL_TABS));
-//                   ||
-//                    getSkinnable().getTabClosingPolicy().equals(TabPane.TabClosingPolicy.SELECTED_TAB) && tab.isSelected());
+            boolean allTabsPolicy = getSkinnable().getTabClosingPolicy().equals(TabPane.TabClosingPolicy.ALL_TABS);
+            boolean selectedTabPolicy = getSkinnable().getTabClosingPolicy().equals(TabPane.TabClosingPolicy.SELECTED_TAB) && tab.isSelected();
+            return (tab.isClosable() && (allTabsPolicy || selectedTabPolicy));
         }
 
         private void removeListeners() {


### PR DESCRIPTION
support  SELECTED_TAB policy  #75 
@jfoenixadmin 

![tabpane](https://user-images.githubusercontent.com/28135975/87238750-2455bc80-c439-11ea-9570-3972b79e30fb.gif)

Just add the following configuration：
`tabPane.setTabClosingPolicy(TabPane.TabClosingPolicy.SELECTED_TAB);`