### PR TITLE
Fix raw use of parameterized class

### DIFF
--- a/jfoenix/src/main/java/com/jfoenix/transitions/JFXKeyFrame.java
+++ b/jfoenix/src/main/java/com/jfoenix/transitions/JFXKeyFrame.java
@@ -37,9 +37,9 @@ public class JFXKeyFrame {
     private Set<JFXKeyValue<?>> keyValues = new CopyOnWriteArraySet<>();
     private Supplier<Boolean> animateCondition = null;
 
-    public JFXKeyFrame(Duration duration, JFXKeyValue... keyValues) {
+    public JFXKeyFrame(Duration duration, JFXKeyValue<?>... keyValues) {
         this.duration = duration;
-        for (final JFXKeyValue keyValue : keyValues) {
+        for (final JFXKeyValue<?> keyValue : keyValues) {
             if (keyValue != null) {
                 this.keyValues.add(keyValue);
             }
@@ -79,8 +79,8 @@ public class JFXKeyFrame {
             return this;
         }
 
-        public Builder setKeyValues(JFXKeyValue... keyValues) {
-            for (final JFXKeyValue keyValue : keyValues) {
+        public Builder setKeyValues(JFXKeyValue<?>... keyValues) {
+            for (final JFXKeyValue<?> keyValue : keyValues) {
                 if (keyValue != null) {
                     this.keyValues.add(keyValue);
                 }

--- a/jfoenix/src/main/java/com/jfoenix/transitions/JFXKeyValue.java
+++ b/jfoenix/src/main/java/com/jfoenix/transitions/JFXKeyValue.java
@@ -60,7 +60,7 @@ public class JFXKeyValue<T> {
     }
 
     public boolean isValid() {
-        return animateCondition == null ? true : animateCondition.get();
+        return animateCondition == null || animateCondition.get();
     }
 
 


### PR DESCRIPTION
`JFXKeyFrame` used instead of `JFXKeyFrame<?>`. Also simplified a return statement. If this is unintended I will go through the entire project and fix similar problems with generics, and add the commits before merge.